### PR TITLE
LIBSEARCH-120. Modified environment banner to support custom colors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ test/dummy/db/*.sqlite3-journal
 test/dummy/log/*.log
 test/dummy/tmp/
 test/dummy/.sass-cache
+
+.byebug_history

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,7 @@ GEM
     arel (9.0.0)
     ast (2.4.0)
     builder (3.2.3)
+    byebug (11.0.1)
     chunky_png (1.3.10)
     compass (1.0.3)
       chunky_png (~> 1.2)
@@ -200,9 +201,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  byebug
   quick_search-umd_theme!
   rubocop (= 0.52.1)
   sqlite3
 
 BUNDLED WITH
-   1.16.3
+   1.16.6

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 A gem engine providing the UMD Libraries theme used with NCSU Quick Search
 
 This code originated from the NCSU quick_search-generic theme
-[https://github.com/NCSU-Libraries/quick_search-generic_theme]
-(https://github.com/NCSU-Libraries/quick_search-generic_theme).
+[https://github.com/NCSU-Libraries/quick_search-generic_theme][1].
 
 ## Usage
 
@@ -24,3 +23,49 @@ When changing themes, run
 ```
 
 to remove any pre-compiled remmants of the previous theme.
+
+## Environment Banner
+
+In keeping with [SSDR policy][2], an "environment banner" will be displayed at
+the top of each page when running on non-production servers, indicating whether
+the application is running on a "Local", "Development", or "Staging" server.
+This banner does not appear on production systems.
+
+The environment banner will attempt to auto-detect the correct environment. To
+override this auto-detection functionality (or to modify it for testing), the
+following environment variables can be used, all of which are optional:
+
+* ENVIRONMENT_BANNER - the human-readable text to display in the banner
+* ENVIRONMENT_BANNER_FOREGROUND - The color for the banner text (using CSS
+    color codes). When using hexadecial codes, enclose the code in
+    single quotes (i.e., '#00ffff').
+* ENVIRONMENT_BANNER_BACKGROUND - The color for the banner background (using CSS
+    color codes). When using hexadecial codes, enclose the code in
+    single quotes (i.e., '#00ffff').
+* ENVIRONMENT_BANNER_ENABLED - Set to "true" to display the banner when it
+    otherwise would not (for example, on a production server). The
+    "ENVIRONMENT_BANNER" variable must also be set.
+
+The environment banner can also be configured using an initializer in the
+application, i.e. "config/initializers/quick_search_umd_theme.rb":
+
+```
+  QuickSearchUmdTheme.configure do |config|
+    # These settings override any settings in the environment variables
+    config.environment_banner.text = 'Alpha Release'
+    config.environment_banner.css_options = {
+      style: 'color: red; background-color: yellow;',
+      class: 'environment-banner'
+    }
+    config.environment_banner.enabled = true
+  end
+```
+
+**Note:** The environment banner configuration is cached when the application
+is started, so any changes to the configuration will require an application
+restart.
+
+----
+
+[1]: https://github.com/NCSU-Libraries/quick_search-generic_theme
+[2]: https://confluence.umd.edu/display/LIB/Create+Environment+Banners

--- a/app/helpers/quick_search_umd_theme/umd_environment_banner_helper.rb
+++ b/app/helpers/quick_search_umd_theme/umd_environment_banner_helper.rb
@@ -3,26 +3,17 @@
 require 'socket'
 
 module QuickSearchUmdTheme
-  # This Helper does the "UMD Environment Banner"
+  # This Helper creates the "UMD Environment Banner" as required by
   # https://confluence.umd.edu/display/LIB/Create+Environment+Banners
   module UmdEnvironmentBannerHelper
-    ENVIRONMENT_NAME = if ENV['ENVIRONMENT_BANNER']
-                         ENV['ENVIRONMENT_BANNER'].freeze
-                       elsif Rails.env.development?
-                         'Local'
-                       elsif Socket.gethostname =~ /(local|dev|stage)\./
-                         $LAST_MATCH_INFO.captures
-                                         .first
-                                         .gsub('dev', 'development')
-                                         .humanize
-                                         .freeze
-                       end
-
+    # Returns the HTML tag for the environment banner, or nil if no banner
+    # should be displayed.
     def environment_banner
-      return unless ENVIRONMENT_NAME
-      content_tag(:div, "#{ENVIRONMENT_NAME} Environment",
-                  class: 'environment-banner',
-                  id: "environment-#{ENVIRONMENT_NAME.gsub(/\W/i, '_').underscore}")
+      QuickSearchUmdTheme.configure
+      return unless QuickSearchUmdTheme.configuration.environment_banner.enabled?
+      banner_text = QuickSearchUmdTheme.configuration.environment_banner.text
+      css_options = QuickSearchUmdTheme.configuration.environment_banner.css_options
+      content_tag(:div, banner_text, css_options)
     end
   end
 end

--- a/lib/quick_search-umd_theme.rb
+++ b/lib/quick_search-umd_theme.rb
@@ -2,4 +2,152 @@ require 'quick_search_umd_theme/engine'
 
 # UMD Theme for quick search application
 module QuickSearchUmdTheme
+  class << self
+    attr_accessor :configuration
+  end
+
+  def self.configure
+    self.configuration ||= Configuration.new
+    yield(configuration) if block_given?
+  end
+
+  class Configuration
+    attr_accessor :environment_banner
+
+    def initialize
+      @environment_banner = EnvironmentBannerConfiguration.new
+    end
+  end
+
+  # Configures the environment banner.
+  #
+  # The default configuration uses the following environment variables,
+  # all of which are optional:
+  #
+  # ENVIRONMENT_BANNER - The exact text to display in the banner
+  # ENVIRONMENT_BANNER_FOREGROUND - The color for the banner text (using CSS
+  #   color codes). When using hexadecial codes, enclose the code in
+  #   single quotes (i.e., '#00ffff').
+  # ENVIRONMENT_BANNER_BACKGROUND - The color for the banner background (using
+  #   CSS color codes). When using hexadecial codes, enclose the code in
+  #   single quotes (i.e., '#00ffff').
+  # ENVIRONMENT_BANNER_ENABLED - Set to "true" to display the banner when it
+  #   otherwise would not (for example, on a production server). The
+  #  "ENVIRONMENT_BANNER" variable must also be set.
+  #
+  # Instead of using environment variables, the configuration can also be set
+  # using an initializer in the application, i.e.
+  #
+  # config/initializers/quick_search_umd_theme.rb
+  #
+  # -----
+  # QuickSearchUmdTheme.configure do |config|
+  #   # These settings override any settings in the environment variables
+  #   config.environment_banner.text = 'Alpha Release'
+  #   config.environment_banner.css_options = {
+  #     style: 'color: red; background-color: yellow;',
+  #     class: 'environment-banner'
+  #   }
+  #   config.environment_banner.enabled = true
+  # end
+  # -----
+
+  class EnvironmentBannerConfiguration
+    attr_accessor :text
+    attr_accessor :css_options
+    attr_accessor :enabled
+
+    def initialize
+      @text = default_text
+      @css_options = default_css_options
+      @enabled = default_enabled(@text)
+    end
+
+    def enabled?
+      @enabled
+    end
+
+    # Returns the text to display in the environment banner.
+    #
+    # Implementation: Returns the value of the ENVIRONMENT_BANNER property, if
+    # non-empty. Otherwise, the text returned by the "environment_descriptor"
+    # method is returned, with " Environment" appended.
+    #
+    # This method may return nil, if there is no ENVIRONMENT_BANNER, and
+    # the environment_desriptor returns nil.
+    def default_text
+      if ENV['ENVIRONMENT_BANNER'].present?
+         ENV['ENVIRONMENT_BANNER'].freeze
+      elsif environment_descriptor
+        (environment_descriptor + ' Environment').freeze
+      end
+    end
+
+    # Returns the CSS options to use with the environment banner.
+    #
+    # Implementation: Uses the ENVIRONMENT_BANNER_BACKGROUND and
+    # ENVIRONMENT_BANNER_FOREGROUND properties, if provided. Also returns an
+    # "id" field, based on the environment_descriptor, if non-nil.
+    def default_css_options
+      css_options = {}
+      css_style = ''
+
+      background_color = ENV['ENVIRONMENT_BANNER_BACKGROUND']
+      foreground_color = ENV['ENVIRONMENT_BANNER_FOREGROUND']
+
+      if background_color.present?
+        css_style = "background-color: #{background_color};"
+      end
+
+      if foreground_color.present?
+        css_style += " color: #{foreground_color};"
+        css_style.strip!
+      end
+
+      if !css_style.blank?
+        css_options[:style] = css_style
+      end
+
+      if environment_descriptor
+        css_options[:id] = "environment-#{environment_descriptor.gsub(/\W/i, '_').underscore}"
+      end
+
+      css_options[:class] = 'environment-banner'
+      css_options
+    end
+
+    # Returns true if the banner should be displayed, false otherwise.
+    #
+    # text - the text (if any) being displayedin the banner
+    def default_enabled(text)
+      env_var_enabled = ENV['ENVIRONMENT_BANNER_ENABLED']
+
+      # Don't display the banner if there is no text
+      has_display_text = text.present? && !text.empty?
+      return false unless has_display_text
+
+      # Display in ENVIRONMENT_BANNER_ENABLED is not provided or empty
+      return true if env_var_enabled.nil? || env_var_enabled.empty?
+
+      # Any value other than "true" is false
+      env_var_enabled.strip.downcase == 'true'
+    end
+
+    # Returns a description of the running environment (Local, Development,
+    # Stage), or nil if the environment can't be determined.
+    #
+    # Implementation: Returns 'Local', if Rails.env.development?, or "Local",
+    # "Development", "Stage", if the hostname constains "local.", "dev.", or
+    # "stage.", otherwise returns nil.
+    def environment_descriptor
+      if Rails.env.development?
+        'Local'
+      elsif Socket.gethostname =~ /(local|dev|stage)\./
+        Regexp.last_match.captures
+                          .first
+                          .gsub('dev', 'development')
+                          .humanize
+      end
+    end
+  end
 end

--- a/quick_search-umd_theme.gemspec
+++ b/quick_search-umd_theme.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'sass', '~> 3.2'
   s.add_dependency 'sass-rails', '~> 5.0'
 
+  s.add_development_dependency('byebug')
   s.add_development_dependency('rubocop', '0.52.1')
   s.add_development_dependency('sqlite3')
 end

--- a/test/helpers/quick_search_umd_theme_config_test.rb
+++ b/test/helpers/quick_search_umd_theme_config_test.rb
@@ -1,0 +1,216 @@
+require 'test_helper'
+require 'minitest/mock'
+
+class QuickSearchUmdThemeConfigText < ActiveSupport::TestCase
+  def setup
+  end
+
+  test 'environment_descriptor returns name of environment' do
+    Rails.env = 'local'
+    config = QuickSearchUmdTheme::Configuration.new
+    assert 'Local', config.environment_banner.environment_descriptor
+  end
+
+  test 'environment_descriptor with socket' do
+    Socket.stub :gethostname, 'search-local.lib.umd.edu' do
+      config = QuickSearchUmdTheme::Configuration.new
+      assert_equal 'Local', config.environment_banner.environment_descriptor
+    end
+
+    Socket.stub :gethostname, 'search-dev.lib.umd.edu' do
+      config = QuickSearchUmdTheme::Configuration.new
+      assert_equal 'Development', config.environment_banner.environment_descriptor
+    end
+
+    Socket.stub :gethostname, 'search-stage.lib.umd.edu' do
+      config = QuickSearchUmdTheme::Configuration.new
+      assert_equal 'Stage', config.environment_banner.environment_descriptor
+    end
+
+    Socket.stub :gethostname, 'search.lib.umd.edu' do
+      config = QuickSearchUmdTheme::Configuration.new
+      assert_nil config.environment_banner.environment_descriptor
+    end
+  end
+
+  test 'default_text with socket' do
+    Socket.stub :gethostname, 'search-local.lib.umd.edu' do
+      config = QuickSearchUmdTheme::Configuration.new
+      assert_equal 'Local Environment', config.environment_banner.default_text
+    end
+
+    Socket.stub :gethostname, 'search-dev.lib.umd.edu' do
+      config = QuickSearchUmdTheme::Configuration.new
+      assert_equal 'Development Environment', config.environment_banner.default_text
+    end
+
+    Socket.stub :gethostname, 'search-stage.lib.umd.edu' do
+      config = QuickSearchUmdTheme::Configuration.new
+      assert_equal 'Stage Environment', config.environment_banner.default_text
+    end
+
+    Socket.stub :gethostname, 'search.lib.umd.edu' do
+      config = QuickSearchUmdTheme::Configuration.new
+      assert_nil config.environment_banner.default_text
+    end
+  end
+
+  test 'default_text with ENVIRONMENT_BANNER variable' do
+    ENV['ENVIRONMENT_BANNER'] = 'Foobar'
+    config = QuickSearchUmdTheme::Configuration.new
+    assert_equal 'Foobar', config.environment_banner.default_text
+
+    ENV['ENVIRONMENT_BANNER'] = ''
+    Rails.env = 'development'
+    config = QuickSearchUmdTheme::Configuration.new
+    assert_equal 'Local Environment', config.environment_banner.default_text
+
+    ENV['ENVIRONMENT_BANNER'] = nil
+    Rails.env = 'development'
+    config = QuickSearchUmdTheme::Configuration.new
+    assert_equal 'Local Environment', config.environment_banner.default_text
+  end
+
+  test 'default_css_options with ENVIRONMENT_BANNER_BACKGROUND variable' do
+    ENV['ENVIRONMENT_BANNER_BACKGROUND'] = 'red'
+    config = QuickSearchUmdTheme::Configuration.new
+
+    css_options = config.environment_banner.default_css_options
+    assert css_options.has_key?(:style)
+    assert_equal 'background-color: red;', css_options[:style]
+
+    assert css_options.has_key?(:class)
+    assert_equal 'environment-banner', css_options[:class]
+
+    # Test with empty property
+    ENV['ENVIRONMENT_BANNER_BACKGROUND'] = ''
+    config = QuickSearchUmdTheme::Configuration.new
+
+    css_options = config.environment_banner.default_css_options
+    refute css_options.has_key?(:style)
+    assert_equal 'environment-banner', css_options[:class]
+
+    # Test with nil property
+    ENV['ENVIRONMENT_BANNER_BACKGROUND'] = nil
+    config = QuickSearchUmdTheme::Configuration.new
+
+    css_options = config.environment_banner.default_css_options
+    refute css_options.has_key?(:style)
+    assert_equal 'environment-banner', css_options[:class]
+  end
+
+  test 'default_css_options with ENVIRONMENT_BANNER_FOREGROUND variable' do
+    ENV['ENVIRONMENT_BANNER_FOREGROUND'] = 'white'
+    config = QuickSearchUmdTheme::Configuration.new
+
+    css_options = config.environment_banner.default_css_options
+    assert css_options.has_key?(:style)
+    assert_equal 'color: white;', css_options[:style]
+
+    assert css_options.has_key?(:class)
+    assert_equal 'environment-banner', css_options[:class]
+
+    # Test with empty property
+    ENV['ENVIRONMENT_BANNER_FOREGROUND'] = ''
+    config = QuickSearchUmdTheme::Configuration.new
+
+    css_options = config.environment_banner.default_css_options
+    refute css_options.has_key?(:style)
+    assert_equal 'environment-banner', css_options[:class]
+
+    # Test with nil property
+    ENV['ENVIRONMENT_BANNER_FOREGROUND'] = nil
+    config = QuickSearchUmdTheme::Configuration.new
+
+    css_options = config.environment_banner.default_css_options
+    refute css_options.has_key?(:style)
+    assert_equal 'environment-banner', css_options[:class]
+  end
+
+  test 'default_css_options with ENVIRONMENT_BANNER_BACKGROUND and ENVIRONMENT_BANNER_FOREGROUND variables' do
+    ENV['ENVIRONMENT_BANNER_BACKGROUND'] = 'red'
+    ENV['ENVIRONMENT_BANNER_FOREGROUND'] = 'white'
+    config = QuickSearchUmdTheme::Configuration.new
+
+    css_options =config.environment_banner.default_css_options
+    assert css_options.has_key?(:style)
+    assert_equal 'background-color: red; color: white;', css_options[:style]
+
+    assert css_options.has_key?(:class)
+    assert_equal 'environment-banner', css_options[:class]
+  end
+
+  test 'default_css_options "id" handling with socket' do
+    Socket.stub :gethostname, 'search-local.lib.umd.edu' do
+      config = QuickSearchUmdTheme::Configuration.new
+      assert_equal 'environment-local', config.environment_banner.default_css_options[:id].downcase
+    end
+
+    Socket.stub :gethostname, 'search-dev.lib.umd.edu' do
+      config = QuickSearchUmdTheme::Configuration.new
+      assert_equal 'environment-development', config.environment_banner.default_css_options[:id].downcase
+    end
+
+    Socket.stub :gethostname, 'search-stage.lib.umd.edu' do
+      config = QuickSearchUmdTheme::Configuration.new
+      assert_equal 'environment-stage', config.environment_banner.default_css_options[:id].downcase
+    end
+
+    Socket.stub :gethostname, 'search.lib.umd.edu' do
+      config = QuickSearchUmdTheme::Configuration.new
+      assert_nil config.environment_banner.default_css_options[:id]
+    end
+  end
+
+  test 'default_enabled with socket' do
+    Socket.stub :gethostname, 'search-local.lib.umd.edu' do
+      config = QuickSearchUmdTheme::Configuration.new
+      assert config.environment_banner.default_enabled(config.environment_banner.default_text)
+    end
+
+    Socket.stub :gethostname, 'search-dev.lib.umd.edu' do
+      config = QuickSearchUmdTheme::Configuration.new
+      assert config.environment_banner.default_enabled(config.environment_banner.default_text)
+    end
+
+    Socket.stub :gethostname, 'search-stage.lib.umd.edu' do
+      config = QuickSearchUmdTheme::Configuration.new
+      assert config.environment_banner.default_enabled(config.environment_banner.default_text)
+    end
+
+    Socket.stub :gethostname, 'search.lib.umd.edu' do
+      config = QuickSearchUmdTheme::Configuration.new
+      refute config.environment_banner.default_enabled(config.environment_banner.default_text)
+    end
+  end
+
+  test 'default_enabled with ENVIRONMENT_BANNER_ENABLED variable' do
+    ENV['ENVIRONMENT_BANNER_ENABLED'] = 'true'
+    text = 'Local Environment'
+    config = QuickSearchUmdTheme::Configuration.new
+    assert config.environment_banner.default_enabled(text)
+
+    ENV['ENVIRONMENT_BANNER_ENABLED'] = 'false'
+    text = 'Local Environment'
+    config = QuickSearchUmdTheme::Configuration.new
+    refute config.environment_banner.default_enabled(text)
+
+    # Don't show banner if there is no text to display
+    ENV['ENVIRONMENT_BANNER_ENABLED'] = 'true'
+    text = ''
+    config = QuickSearchUmdTheme::Configuration.new
+    refute config.environment_banner.default_enabled(text)
+
+    # Can show banner in production, if ENVIRONMENT_BANNER is set
+    Socket.stub :gethostname, 'search.lib.umd.edu' do
+      config = QuickSearchUmdTheme::Configuration.new
+      ENV['ENVIRONMENT_BANNER'] = 'Production Release'
+      assert config.environment_banner.default_enabled(config.environment_banner.default_text)
+    end
+  end
+
+  def teardown
+    ENV.clear
+    Rails.env = 'test'
+  end
+end

--- a/test/helpers/umd_environment_banner_helper_test.rb
+++ b/test/helpers/umd_environment_banner_helper_test.rb
@@ -1,0 +1,67 @@
+require 'test_helper'
+require 'minitest/mock'
+
+class UmdEnvironmentBannerHelperTest < ActiveSupport::TestCase
+  def setup
+    reset_configuration
+    @helper = Object.new
+    @helper.extend(ActionView::Helpers::TagHelper)
+    @helper.extend(QuickSearchUmdTheme::UmdEnvironmentBannerHelper)
+  end
+
+  # Resets the configuration
+  def reset_configuration
+    QuickSearchUmdTheme.configuration = QuickSearchUmdTheme::Configuration.new
+  end
+
+  test 'environment_banner returns expected tag' do
+    Socket.stub :gethostname, 'search-local.lib.umd.edu' do
+      reset_configuration
+      assert_equal(
+        '<div id="environment-local" class="environment-banner">Local Environment</div>',
+        @helper.environment_banner
+      )
+    end
+
+    Socket.stub :gethostname, 'search-dev.lib.umd.edu' do
+      reset_configuration
+      assert_equal(
+        '<div id="environment-development" class="environment-banner">Development Environment</div>',
+        @helper.environment_banner
+      )
+    end
+
+
+    Socket.stub :gethostname, 'search-stage.lib.umd.edu' do
+      reset_configuration
+      assert_equal(
+        '<div id="environment-stage" class="environment-banner">Stage Environment</div>',
+        @helper.environment_banner
+      )
+    end
+
+
+    Socket.stub :gethostname, 'search.lib.umd.edu' do
+      reset_configuration
+      assert_nil @helper.environment_banner
+    end
+
+
+    ENV['ENVIRONMENT_BANNER'] = 'Alpha Release'
+    ENV['ENVIRONMENT_BANNER_BACKGROUND'] = 'yellow'
+    ENV['ENVIRONMENT_BANNER_FOREGROUND'] = 'black'
+
+    Socket.stub :gethostname, 'search.lib.umd.edu' do
+      reset_configuration
+      assert_equal(
+        '<div style="background-color: yellow; color: black;" class="environment-banner">Alpha Release</div>',
+        @helper.environment_banner
+      )
+    end
+  end
+
+  def teardown
+    ENV.clear
+    Rails.env = 'test'
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,7 @@ require File.expand_path('../../test/dummy/config/environment.rb', __FILE__)
 ActiveRecord::Migrator.migrations_paths = [File.expand_path('../../test/dummy/db/migrate', __FILE__)]
 ActiveRecord::Migrator.migrations_paths << File.expand_path('../../db/migrate', __FILE__)
 require 'rails/test_help'
+require 'byebug'
 
 # Filter out Minitest backtrace while allowing backtrace from other libraries
 # to be shown.


### PR DESCRIPTION
Moved default configuration and display logic out of the
"umd_environment_banner_helper.rb" file into
lib/quick_search-umd_theme.rb, as suggested in

https://rarlindseysmash.com/posts/config-and-generators-in-gems

This has the advantage that the configuration and display logic will
only run once per application start, minimizing the amount of time it
takes to generate the banner.

The banner can be configured using the following (optional)
environment variables:

* ENVIRONMENT_BANNER
* ENVIRONMENT_BANNER_FOREGROUND
* ENVIRONMENT_BANNER_BACKGROUND
* ENVIRONMENT_BANNER_ENABLED

The ENVIRONMENT_BANNER_ENABLED is only needed to force the banner to
be displayed when it otherwise wouldn't be (such as on a production
server).

Added "byebug" as a development dependency to help troubleshoot
tests.

https://issues.umd.edu/browse/LIBSEARCH-120